### PR TITLE
fix: updated webhook API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
-	github.com/reinoudk/go-sonarcloud v0.3.1
+	github.com/reinoudk/go-sonarcloud v0.3.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/reinoudk/go-sonarcloud v0.3.1 h1:B2rBAZmMnQKj3Go4dLqCFM4Lt576Ujxkrbat4vVX5Aw=
-github.com/reinoudk/go-sonarcloud v0.3.1/go.mod h1:kt+3/8ztZGlmyBGkKOm/nTPi+FhkboKcuX7R0SylqwI=
+github.com/reinoudk/go-sonarcloud v0.3.4 h1:7xbu4LrOvqrdkg5iIlqxBG3UdcdYhBMPTqh6bJju8dQ=
+github.com/reinoudk/go-sonarcloud v0.3.4/go.mod h1:kt+3/8ztZGlmyBGkKOm/nTPi+FhkboKcuX7R0SylqwI=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/sonarcloud/data_source_webhooks.go
+++ b/sonarcloud/data_source_webhooks.go
@@ -3,6 +3,7 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -43,11 +44,10 @@ func (d dataSourceWebhooksType) GetSchema(_ context.Context) (tfsdk.Schema, diag
 						Computed:    true,
 						Description: "The url of the webhook.",
 					},
-					"secret": {
-						Type:        types.StringType,
+					"has_secret": {
+						Type:        types.BoolType,
 						Computed:    true,
-						Description: "The secret of the webhook. Used as the key to generate the HMAC hex (lowercase) digest value in the 'X-Sonar-Webhook-HMAC-SHA256' header.",
-						Sensitive:   true,
+						Description: "Whether the webhook has a secret.",
 					},
 				}),
 			},
@@ -91,10 +91,10 @@ func (d dataSourceWebhooks) Read(ctx context.Context, req tfsdk.ReadDataSourceRe
 	hooks := make([]DataWebhook, len(response.Webhooks))
 	for i, webhook := range response.Webhooks {
 		hooks[i] = DataWebhook{
-			Key:    types.String{Value: webhook.Key},
-			Name:   types.String{Value: webhook.Name},
-			Secret: types.String{Value: webhook.Secret},
-			Url:    types.String{Value: webhook.Url},
+			Key:       types.String{Value: webhook.Key},
+			Name:      types.String{Value: webhook.Name},
+			HasSecret: types.Bool{Value: webhook.HasSecret},
+			Url:       types.String{Value: webhook.Url},
 		}
 	}
 

--- a/sonarcloud/data_source_webhooks_test.go
+++ b/sonarcloud/data_source_webhooks_test.go
@@ -2,9 +2,10 @@ package sonarcloud
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func testAccPreCheckDataSourceWebhooks(t *testing.T) {
@@ -29,7 +30,7 @@ func TestAccDataSourceWebhooks(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.sonarcloud_webhooks.test", "webhooks.0.key"),
 					resource.TestCheckResourceAttrSet("data.sonarcloud_webhooks.test", "webhooks.0.name"),
 					resource.TestCheckResourceAttrSet("data.sonarcloud_webhooks.test", "webhooks.0.url"),
-					resource.TestCheckResourceAttrSet("data.sonarcloud_webhooks.test", "webhooks.0.secret"),
+					resource.TestCheckResourceAttrSet("data.sonarcloud_webhooks.test", "webhooks.0.has_secret"),
 				),
 			},
 		},

--- a/sonarcloud/models.go
+++ b/sonarcloud/models.go
@@ -159,10 +159,10 @@ type DataWebhooks struct {
 }
 
 type DataWebhook struct {
-	Key    types.String `tfsdk:"key"`
-	Name   types.String `tfsdk:"name"`
-	Secret types.String `tfsdk:"secret"`
-	Url    types.String `tfsdk:"url"`
+	Key       types.String `tfsdk:"key"`
+	Name      types.String `tfsdk:"name"`
+	HasSecret types.Bool   `tfsdk:"has_secret"`
+	Url       types.String `tfsdk:"url"`
 }
 
 type Webhook struct {

--- a/sonarcloud/resource_webhook_test.go
+++ b/sonarcloud/resource_webhook_test.go
@@ -2,10 +2,11 @@ package sonarcloud
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccWebhook(t *testing.T) {
@@ -92,6 +93,7 @@ func webhookImportCheck(resourceName, project string) resource.TestStep {
 			id := state.RootModule().Resources[resourceName].Primary.ID
 			return fmt.Sprintf("%s,%s", id, project), nil
 		},
-		ImportStateVerify: true,
+		// We need to set ImportStateVerify to false because we cannot read the secret value from the API.
+		ImportStateVerify: false,
 	}
 }


### PR DESCRIPTION
The webhook API does not return the secret value anymore, just whether a secret as been set or not.

BREAKING CHANGE: webhook secret values are no longer read back from the API