### PR TITLE
Replace stale go-sonarcloud dependency with my fixed fork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist/
 
 # VSCode files
 **/.vscode/**
+
+# Local Development
+**/*.sh

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The project should have the following 3 groups:
 - Owners (Should be auto-created as well) - with 1 member
 - TEST_DONT_REMOVE - with 0 members (see environment variables below to see how to customize this)
 
-Acceptance tests also rely on the following preconfigured SonarCloud Resources:
+Acceptance tests also rely on the following pre-configured SonarCloud Resources:
 
 - One test Quality Gate
 - One test Project
@@ -46,5 +46,5 @@ Acceptance tests also rely on the following preconfigured SonarCloud Resources:
 | `SONARCLOUD_TEST_GROUP_NAME` | The name of an existing group to which the test-user will be added and removed from. | 
 | `SONARCLOUD_TOKEN_TEST_USER_LOGIN` | The login for testing `sonarcloud_user_token`. This must be the login that also has the existing `SONARCLOUD_TOKEN`. |
 | `SONARCLOUD_PROJECT_KEY` | The Key of a test `project` for testing the `sonarcloud_quality_gate_selection` resource. |
-| `SONARCLOUD_QUALITY_GATE_ID` | The `GateId` of a test `Quality Gate` for testing `sonarcloud_qualtiy_gate_selection` resource. |
-| `SONARCLOUD_QUALITY_GATE_NAME` | The `name` of a test `Quality Gate` for testing the `sonarcloud_qualtiy_gate` data source. |
+| `SONARCLOUD_QUALITY_GATE_ID` | The `GateId` of a test `Quality Gate` for testing `sonarcloud_quality_gate_selection` resource. |
+| `SONARCLOUD_QUALITY_GATE_NAME` | The `name` of a test `Quality Gate` for testing the `sonarcloud_quality_gate` data source. |

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
-	github.com/reinoudk/go-sonarcloud v0.3.1
+	github.com/reinoudk/go-sonarcloud v0.3.4
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module terraform-provider-sonarcloud
 go 1.18
 
 require (
+	github.com/ArgonGlow/go-sonarcloud v0.4.1
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.20.0
-	github.com/reinoudk/go-sonarcloud v0.3.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/reinoudk/go-sonarcloud v0.3.1 h1:B2rBAZmMnQKj3Go4dLqCFM4Lt576Ujxkrbat4vVX5Aw=
 github.com/reinoudk/go-sonarcloud v0.3.1/go.mod h1:kt+3/8ztZGlmyBGkKOm/nTPi+FhkboKcuX7R0SylqwI=
+github.com/reinoudk/go-sonarcloud v0.3.4 h1:7xbu4LrOvqrdkg5iIlqxBG3UdcdYhBMPTqh6bJju8dQ=
+github.com/reinoudk/go-sonarcloud v0.3.4/go.mod h1:kt+3/8ztZGlmyBGkKOm/nTPi+FhkboKcuX7R0SylqwI=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/ArgonGlow/go-sonarcloud v0.4.1 h1:im5AQ5ytnCzBfH5fSMIgbGun16QeFwSkJzVtqTn6Oh8=
+github.com/ArgonGlow/go-sonarcloud v0.4.1/go.mod h1:PBF26JjjKI9Tr7+x+AxtSDxLQPGVhVHOu34UKWaLAIE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -222,8 +224,6 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/reinoudk/go-sonarcloud v0.3.4 h1:7xbu4LrOvqrdkg5iIlqxBG3UdcdYhBMPTqh6bJju8dQ=
-github.com/reinoudk/go-sonarcloud v0.3.4/go.mod h1:kt+3/8ztZGlmyBGkKOm/nTPi+FhkboKcuX7R0SylqwI=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=

--- a/sonarcloud/data_source_project_links.go
+++ b/sonarcloud/data_source_project_links.go
@@ -3,10 +3,11 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
+	pl "github.com/ArgonGlow/go-sonarcloud/sonarcloud/project_links"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	pl "github.com/reinoudk/go-sonarcloud/sonarcloud/project_links"
 )
 
 type dataSourceProjectLinksType struct{}

--- a/sonarcloud/data_source_projects.go
+++ b/sonarcloud/data_source_projects.go
@@ -3,10 +3,11 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/projects"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/projects"
 )
 
 type dataSourceProjectsType struct{}

--- a/sonarcloud/data_source_quality_gate.go
+++ b/sonarcloud/data_source_quality_gate.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/qualitygates"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/qualitygates"
 )
 
 type dataSourceQualityGateType struct{}

--- a/sonarcloud/data_source_quality_gates.go
+++ b/sonarcloud/data_source_quality_gates.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/qualitygates"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/qualitygates"
 )
 
 type dataSourceQualityGatesType struct{}

--- a/sonarcloud/data_source_user_group.go
+++ b/sonarcloud/data_source_user_group.go
@@ -3,10 +3,11 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/user_groups"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/user_groups"
 )
 
 type dataSourceUserGroupType struct{}

--- a/sonarcloud/data_source_user_group_members.go
+++ b/sonarcloud/data_source_user_group_members.go
@@ -3,10 +3,11 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/user_groups"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/user_groups"
 )
 
 type dataSourceUserGroupMembersType struct{}

--- a/sonarcloud/data_source_user_group_permissions.go
+++ b/sonarcloud/data_source_user_group_permissions.go
@@ -3,11 +3,12 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud"
 )
 
 type dataSourceUserGroupPermissionsType struct{}

--- a/sonarcloud/data_source_user_groups.go
+++ b/sonarcloud/data_source_user_groups.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/user_groups"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/user_groups"
 )
 
 type dataSourceUserGroupsType struct{}

--- a/sonarcloud/data_source_user_permissions.go
+++ b/sonarcloud/data_source_user_permissions.go
@@ -3,11 +3,12 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud"
 )
 
 type dataSourceUserPermissionsType struct{}

--- a/sonarcloud/data_source_webhooks.go
+++ b/sonarcloud/data_source_webhooks.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/webhooks"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/webhooks"
 )
 
 type dataSourceWebhooksType struct{}

--- a/sonarcloud/data_source_webhooks.go
+++ b/sonarcloud/data_source_webhooks.go
@@ -3,6 +3,7 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -91,10 +92,10 @@ func (d dataSourceWebhooks) Read(ctx context.Context, req tfsdk.ReadDataSourceRe
 	hooks := make([]DataWebhook, len(response.Webhooks))
 	for i, webhook := range response.Webhooks {
 		hooks[i] = DataWebhook{
-			Key:    types.String{Value: webhook.Key},
-			Name:   types.String{Value: webhook.Name},
-			Secret: types.String{Value: webhook.Secret},
-			Url:    types.String{Value: webhook.Url},
+			Key:       types.String{Value: webhook.Key},
+			Name:      types.String{Value: webhook.Name},
+			HasSecret: types.Bool{Value: webhook.HasSecret},
+			Url:       types.String{Value: webhook.Url},
 		}
 	}
 

--- a/sonarcloud/helpers.go
+++ b/sonarcloud/helpers.go
@@ -2,21 +2,22 @@ package sonarcloud
 
 import (
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
 	"math/big"
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/project_branches"
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/projects"
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/qualitygates"
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/user_groups"
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/user_tokens"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/project_branches"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/projects"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/qualitygates"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/user_groups"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/user_tokens"
 )
 
 // changedAttrs returns a map where the keys are the names of all the attributes that were changed

--- a/sonarcloud/models.go
+++ b/sonarcloud/models.go
@@ -166,10 +166,11 @@ type DataWebhook struct {
 }
 
 type Webhook struct {
-	ID      types.String `tfsdk:"id"`
-	Key     types.String `tfsdk:"key"`
-	Project types.String `tfsdk:"project"`
-	Name    types.String `tfsdk:"name"`
-	Secret  types.String `tfsdk:"secret"`
-	Url     types.String `tfsdk:"url"`
+	ID           types.String `tfsdk:"id"`
+	Key          types.String `tfsdk:"key"`
+	Project      types.String `tfsdk:"project"`
+	Organization types.String `tfsdk:"organization"`
+	Name         types.String `tfsdk:"name"`
+	Secret       types.String `tfsdk:"secret"`
+	Url          types.String `tfsdk:"url"`
 }

--- a/sonarcloud/models.go
+++ b/sonarcloud/models.go
@@ -159,17 +159,18 @@ type DataWebhooks struct {
 }
 
 type DataWebhook struct {
-	Key    types.String `tfsdk:"key"`
-	Name   types.String `tfsdk:"name"`
-	Secret types.String `tfsdk:"secret"`
-	Url    types.String `tfsdk:"url"`
+	Key       types.String `tfsdk:"key"`
+	Name      types.String `tfsdk:"name"`
+	HasSecret types.Bool   `tfsdk:"hasSecret,omitempty"`
+	Url       types.String `tfsdk:"url"`
 }
 
 type Webhook struct {
-	ID      types.String `tfsdk:"id"`
-	Key     types.String `tfsdk:"key"`
-	Project types.String `tfsdk:"project"`
-	Name    types.String `tfsdk:"name"`
-	Secret  types.String `tfsdk:"secret"`
-	Url     types.String `tfsdk:"url"`
+	ID        types.String `tfsdk:"id"`
+	Key       types.String `tfsdk:"key"`
+	Project   types.String `tfsdk:"project"`
+	Name      types.String `tfsdk:"name"`
+	HasSecret types.Bool   `tfsdk:"hasSecret,omitempty"`
+	Secret    types.String `tfsdk:"secret,omitempty"`
+	Url       types.String `tfsdk:"url"`
 }

--- a/sonarcloud/models.go
+++ b/sonarcloud/models.go
@@ -161,16 +161,15 @@ type DataWebhooks struct {
 type DataWebhook struct {
 	Key       types.String `tfsdk:"key"`
 	Name      types.String `tfsdk:"name"`
-	HasSecret types.Bool   `tfsdk:"hasSecret,omitempty"`
+	HasSecret types.Bool   `tfsdk:"has_secret"`
 	Url       types.String `tfsdk:"url"`
 }
 
 type Webhook struct {
-	ID        types.String `tfsdk:"id"`
-	Key       types.String `tfsdk:"key"`
-	Project   types.String `tfsdk:"project"`
-	Name      types.String `tfsdk:"name"`
-	HasSecret types.Bool   `tfsdk:"hasSecret,omitempty"`
-	Secret    types.String `tfsdk:"secret,omitempty"`
-	Url       types.String `tfsdk:"url"`
+	ID      types.String `tfsdk:"id"`
+	Key     types.String `tfsdk:"key"`
+	Project types.String `tfsdk:"project"`
+	Name    types.String `tfsdk:"name"`
+	Secret  types.String `tfsdk:"secret"`
+	Url     types.String `tfsdk:"url"`
 }

--- a/sonarcloud/provider.go
+++ b/sonarcloud/provider.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"os"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud"
 )
 
 func New() tfsdk.Provider {

--- a/sonarcloud/resource_project.go
+++ b/sonarcloud/resource_project.go
@@ -3,12 +3,13 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/projects"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/projects"
 )
 
 type resourceProjectType struct{}

--- a/sonarcloud/resource_project_link.go
+++ b/sonarcloud/resource_project_link.go
@@ -3,12 +3,13 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/project_links"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/project_links"
-	"strings"
 )
 
 type resourceProjectLinkType struct{}

--- a/sonarcloud/resource_project_main_branch.go
+++ b/sonarcloud/resource_project_main_branch.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/project_branches"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/project_branches"
 )
 
 type resourceProjectMainBranchType struct{}

--- a/sonarcloud/resource_quality_gate.go
+++ b/sonarcloud/resource_quality_gate.go
@@ -3,12 +3,13 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework/path"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/qualitygates"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/qualitygates"
 )
 
 type resourceQualityGateType struct{}
@@ -444,7 +445,7 @@ func diffName(old, new QualityGate) bool {
 	return true
 }
 
-//Check if a Quality Gate has been set to default
+// Check if a Quality Gate has been set to default
 func diffDefault(old, new QualityGate) bool {
 	if old.IsDefault.Equal(new.IsDefault) {
 		return false

--- a/sonarcloud/resource_quality_gate_selection.go
+++ b/sonarcloud/resource_quality_gate_selection.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/qualitygates"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/qualitygates"
 )
 
 type resourceQualityGateSelectionType struct{}

--- a/sonarcloud/resource_user_group.go
+++ b/sonarcloud/resource_user_group.go
@@ -3,13 +3,14 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"math/big"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/user_groups"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/user_groups"
 )
 
 type resourceUserGroupType struct{}

--- a/sonarcloud/resource_user_group_member.go
+++ b/sonarcloud/resource_user_group_member.go
@@ -3,13 +3,14 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/user_groups"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/user_groups"
 )
 
 type resourceUserGroupMemberType struct{}

--- a/sonarcloud/resource_user_group_permissions.go
+++ b/sonarcloud/resource_user_group_permissions.go
@@ -3,17 +3,18 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud"
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/permissions"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/permissions"
-	"strings"
-	"sync"
-	"time"
 )
 
 type resourceUserGroupPermissionsType struct{}

--- a/sonarcloud/resource_user_permissions.go
+++ b/sonarcloud/resource_user_permissions.go
@@ -3,6 +3,10 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -11,9 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/reinoudk/go-sonarcloud/sonarcloud"
 	"github.com/reinoudk/go-sonarcloud/sonarcloud/permissions"
-	"strings"
-	"sync"
-	"time"
 )
 
 type resourceUserPermissionsType struct{}
@@ -110,8 +111,8 @@ func (r resourceUserPermissions) Create(ctx context.Context, req tfsdk.CreateRes
 	for _, elem := range plan.Permissions.Elems {
 		permission := elem.(types.String).Value
 
+		wg.Add(1)
 		go func() {
-			wg.Add(1)
 			defer wg.Done()
 
 			request := permissions.AddUserRequest{

--- a/sonarcloud/resource_user_permissions.go
+++ b/sonarcloud/resource_user_permissions.go
@@ -7,14 +7,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud"
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/permissions"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/permissions"
 )
 
 type resourceUserPermissionsType struct{}

--- a/sonarcloud/resource_user_token.go
+++ b/sonarcloud/resource_user_token.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/user_tokens"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/user_tokens"
 )
 
 type resourceUserTokenType struct{}

--- a/sonarcloud/resource_webhook.go
+++ b/sonarcloud/resource_webhook.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ArgonGlow/go-sonarcloud/sonarcloud/webhooks"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/reinoudk/go-sonarcloud/sonarcloud/webhooks"
 )
 
 type resourceWebhookType struct{}

--- a/sonarcloud/resource_webhook.go
+++ b/sonarcloud/resource_webhook.go
@@ -3,12 +3,13 @@ package sonarcloud
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/reinoudk/go-sonarcloud/sonarcloud/webhooks"
-	"strings"
 )
 
 type resourceWebhookType struct{}
@@ -107,7 +108,6 @@ func (r resourceWebhook) Create(ctx context.Context, req tfsdk.CreateResourceReq
 		Key:     types.String{Value: webhook.Key},
 		Project: plan.Project,
 		Name:    types.String{Value: webhook.Name},
-		Secret:  types.String{Value: webhook.Secret},
 		Url:     types.String{Value: webhook.Url},
 	}
 	diags = resp.State.Set(ctx, result)
@@ -266,12 +266,12 @@ func findWebhook(response *webhooks.ListResponse, key, project_key string) (Webh
 	for _, webhook := range response.Webhooks {
 		if webhook.Key == key {
 			result = Webhook{
-				ID:      types.String{Value: webhook.Key},
-				Key:     types.String{Value: webhook.Key},
-				Project: types.String{Value: project_key, Null: projectKeyIsNull},
-				Name:    types.String{Value: webhook.Name},
-				Secret:  types.String{Value: webhook.Secret},
-				Url:     types.String{Value: webhook.Url},
+				ID:        types.String{Value: webhook.Key},
+				Key:       types.String{Value: webhook.Key},
+				Project:   types.String{Value: project_key, Null: projectKeyIsNull},
+				Name:      types.String{Value: webhook.Name},
+				HasSecret: types.Bool{Value: webhook.HasSecret},
+				Url:       types.String{Value: webhook.Url},
 			}
 			ok = true
 			break

--- a/sonarcloud/resource_webhook_test.go
+++ b/sonarcloud/resource_webhook_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccWebhook(t *testing.T) {
 	project := os.Getenv("SONARCLOUD_PROJECT_KEY")
+	organization := os.Getenv("SONARCLOUD_ORGANIZATION")
 	secret := "ThisIsNotAVeryGoodSecret..."
 
 	resource.Test(t, resource.TestCase{
@@ -18,7 +19,7 @@ func TestAccWebhook(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectWebhookConfig("test", project, secret, "https://www.example.com"),
+				Config: testAccProjectWebhookConfig("test", project, organization, secret, "https://www.example.com"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sonarcloud_webhook.test", "name", "test"),
 					resource.TestCheckResourceAttr("sonarcloud_webhook.test", "url", "https://www.example.com"),
@@ -27,7 +28,7 @@ func TestAccWebhook(t *testing.T) {
 			},
 			webhookImportCheck("sonarcloud_webhook.test", project),
 			{
-				Config: testAccProjectWebhookConfig("test-two", project, "", "https://www.example.com/test"),
+				Config: testAccProjectWebhookConfig("test-two", project, organization, "", "https://www.example.com/test"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sonarcloud_webhook.test", "name", "test-two"),
 					resource.TestCheckResourceAttr("sonarcloud_webhook.test", "url", "https://www.example.com/test"),
@@ -36,7 +37,7 @@ func TestAccWebhook(t *testing.T) {
 			},
 			webhookImportCheck("sonarcloud_webhook.test", project),
 			{
-				Config: testAccOrganizationWebhookConfig("test", secret, "https://www.example.com"),
+				Config: testAccOrganizationWebhookConfig("test", organization, secret, "https://www.example.com"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sonarcloud_webhook.test", "name", "test"),
 					resource.TestCheckResourceAttr("sonarcloud_webhook.test", "url", "https://www.example.com"),
@@ -45,7 +46,7 @@ func TestAccWebhook(t *testing.T) {
 			},
 			webhookImportCheck("sonarcloud_webhook.test", ""),
 			{
-				Config: testAccOrganizationWebhookConfig("test-two", "", "https://www.example.com/test"),
+				Config: testAccOrganizationWebhookConfig("test-two", organization, "", "https://www.example.com/test"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("sonarcloud_webhook.test", "name", "test-two"),
 					resource.TestCheckResourceAttr("sonarcloud_webhook.test", "url", "https://www.example.com/test"),
@@ -62,26 +63,28 @@ func testAccWebhookDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccProjectWebhookConfig(name, project, secret, url string) string {
+func testAccProjectWebhookConfig(name, project, organization, secret, url string) string {
 	result := fmt.Sprintf(`
 resource "sonarcloud_webhook" "test" {
-  name    = "%s"
-  project = "%s"
-  secret  = "%s"
-  url     = "%s"
+  name         = "%s"
+  project      = "%s"
+	organization = "%s"
+  secret       = "%s"
+  url          = "%s"
 }
-`, name, project, secret, url)
+`, name, project, organization, secret, url)
 	return result
 }
 
-func testAccOrganizationWebhookConfig(name, secret, url string) string {
+func testAccOrganizationWebhookConfig(name, organization, secret, url string) string {
 	result := fmt.Sprintf(`
 resource "sonarcloud_webhook" "test" {
-  name    = "%s"
-  secret  = "%s"
-  url     = "%s"
+  name         = "%s"
+	organization = "%s"
+  secret       = "%s"
+  url          = "%s"
 }
-`, name, secret, url)
+`, name, organization, secret, url)
 	return result
 }
 


### PR DESCRIPTION
- replace imports for `go-sonarcloud` with updated forked repository https://github.com/ArgonGlow/go-sonarcloud
- add now-mandatory `organization` field to webhook model
- update webhook tests accordingly 